### PR TITLE
Prevent persisting the same user multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ class UserDAOImpl @Inject() (db : DB) extends UserDAO {
   }
 
   def save(user: User) = {
-    collection.insert(user)
+    collection.update(Json.obj("userID" -> user.userID),
+      user,
+      upsert = true)
     Future.successful(user)
   }
 }

--- a/app/models/daos/UserDAOImpl.scala
+++ b/app/models/daos/UserDAOImpl.scala
@@ -51,7 +51,9 @@ class UserDAOImpl @Inject() (db : DB) extends UserDAO {
    * @return The saved user.
    */
   def save(user: User) = {
-    collection.insert(user)
+    collection.update(Json.obj("userID" -> user.userID),
+      user,
+      upsert = true)
     Future.successful(user)
   }
 }


### PR DESCRIPTION
The old `save` method in `UserDAOImpl.scala` is using `collection.insert()` which duplicate the same user multiple times in the db every time he logs in.
With the new implementation it adds the user only for the first time and after that it updates it.
